### PR TITLE
Add `showOutput` setting to control the behaviour of the output panel after feeding code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,10 +71,15 @@
                     "default": false,
                     "description": "Enables the linting of Oz files"
                 },
-                "oz.showCompilerOutput": {
+                "oz.showOutput": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Shows the compiler output in the output tab"
+                    "description": "Shows the output in the output tab after feeding"
+                },
+                "oz.focusCompilerOutput": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Focuses the compiler output in the output tab"
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,9 @@ class OzOPIServer {
 
 	private display(channel: vscode.OutputChannel, shouldFocus?: () => boolean) {
 		return function (data: string | Buffer) {
-			channel.show(shouldFocus && shouldFocus());
+			if(vscode.workspace.getConfiguration(OZ_LANGUAGE).get("showOutput", true)){
+				channel.show(shouldFocus && shouldFocus());
+			}
 			channel.append(data.toString());
 		}
 	}
@@ -88,7 +90,7 @@ class OzOPIServer {
 
 			// Dump compiler output in the compiler channel
 			this.compiler.on('data', this.display(this.compilerChannel,
-				() => vscode.workspace.getConfiguration(OZ_LANGUAGE).get("showCompilerOutput", true)
+				() => vscode.workspace.getConfiguration(OZ_LANGUAGE).get("focusCompilerOutput", true)
 			));
 
 			// parse the exceptions with the linter


### PR DESCRIPTION
In case anyone (other than me) finds it annoying that the output panel shows every time code is fed in, I've added the `showOutput` setting to control this behaviour. 